### PR TITLE
Add functions for replace child and replace clause

### DIFF
--- a/lib/src/ast.c
+++ b/lib/src/ast.c
@@ -563,6 +563,7 @@ cypher_astnode_t *cypher_ast_clone(const cypher_astnode_t *ast)
     {
         goto failure;
     }
+    free(children);
     return clone;
 
     int errsv;
@@ -951,6 +952,7 @@ const cypher_astnode_t *cypher_astnode_get_child(const cypher_astnode_t *node,
 void cypher_astnode_set_child(cypher_astnode_t *parent,
         cypher_astnode_t *child, unsigned int index)
 {
+    assert(index < parent->nchildren);
     parent->children[index] = child;
 }
 

--- a/lib/src/ast.c
+++ b/lib/src/ast.c
@@ -948,6 +948,13 @@ const cypher_astnode_t *cypher_astnode_get_child(const cypher_astnode_t *node,
 }
 
 
+void cypher_astnode_set_child(cypher_astnode_t *parent,
+        cypher_astnode_t *child, unsigned int index)
+{
+    parent->children[index] = child;
+}
+
+
 ssize_t snprint_sequence(char *str, size_t size,
         const cypher_astnode_t * const *elements, unsigned int nelements)
 {

--- a/lib/src/ast_query.c
+++ b/lib/src/ast_query.c
@@ -174,6 +174,16 @@ const cypher_astnode_t *cypher_ast_query_get_clause(
 }
 
 
+void cypher_ast_query_set_clause(
+        cypher_astnode_t *astnode, cypher_astnode_t *clause, unsigned int index)
+{
+    REQUIRE_TYPE(astnode, CYPHER_AST_QUERY, NULL);
+    REQUIRE_TYPE(clause, CYPHER_AST_QUERY_CLAUSE, NULL);
+    struct query *node = container_of(astnode, struct query, _astnode);
+    node->clauses[index] = clause;
+}
+
+
 ssize_t detailstr(const cypher_astnode_t *self, char *str, size_t size)
 {
     REQUIRE_TYPE(self, CYPHER_AST_QUERY, -1);

--- a/lib/src/ast_query.c
+++ b/lib/src/ast_query.c
@@ -181,6 +181,7 @@ void cypher_ast_query_set_clause(
     REQUIRE_TYPE(clause, CYPHER_AST_QUERY_CLAUSE, NULL);
     struct query *node = container_of(astnode, struct query, _astnode);
     node->clauses[index] = clause;
+    cypher_astnode_set_child(astnode, clause, index);
 }
 
 

--- a/lib/src/ast_return.c
+++ b/lib/src/ast_return.c
@@ -115,9 +115,9 @@ cypher_astnode_t *clone(const cypher_astnode_t *self,
     }
     cypher_astnode_t *order_by = (node->order_by == NULL) ? NULL :
             children[child_index(self, node->order_by)];
-    cypher_astnode_t *skip = (node->skip != NULL) ? NULL :
+    cypher_astnode_t *skip = (node->skip == NULL) ? NULL :
             children[child_index(self, node->skip)];
-    cypher_astnode_t *limit = (node->limit != NULL) ? NULL :
+    cypher_astnode_t *limit = (node->limit == NULL) ? NULL :
             children[child_index(self, node->limit)];
 
     cypher_astnode_t *clone = cypher_ast_return(node->distinct,

--- a/lib/src/ast_with.c
+++ b/lib/src/ast_with.c
@@ -117,9 +117,9 @@ cypher_astnode_t *clone(const cypher_astnode_t *self,
     }
     cypher_astnode_t *order_by = (node->order_by == NULL) ? NULL :
             children[child_index(self, node->order_by)];
-    cypher_astnode_t *skip = (node->skip != NULL) ? NULL :
+    cypher_astnode_t *skip = (node->skip == NULL) ? NULL :
             children[child_index(self, node->skip)];
-    cypher_astnode_t *limit = (node->limit != NULL) ? NULL :
+    cypher_astnode_t *limit = (node->limit == NULL) ? NULL :
             children[child_index(self, node->limit)];
     cypher_astnode_t *predicate = (node->predicate == NULL) ? NULL :
             children[child_index(self, node->predicate)];

--- a/lib/src/astnode.h
+++ b/lib/src/astnode.h
@@ -127,7 +127,7 @@ static inline int child_index(const cypher_astnode_t *node,
 {
     unsigned int i = 0;
     while (i < node->nchildren && node->children[i] != child)
-        ;
+        i ++;
     assert(i < node->nchildren);
     return i;
 }

--- a/lib/src/cypher-parser.h.in
+++ b/lib/src/cypher-parser.h.in
@@ -454,6 +454,16 @@ __cypherlang_pure
 unsigned int cypher_astnode_nchildren(const cypher_astnode_t *node);
 
 /**
+ * Set the child of an AST node at the given index.
+ *
+ * @param [parent] The AST node to update.
+ * @param [child] The AST node to be inserted.
+ * @param [index] The index of the child.
+ */
+void cypher_astnode_set_child(cypher_astnode_t *parent,
+        cypher_astnode_t *child, unsigned int index);
+
+/**
  * Get a child from an AST node.
  *
  * @param [node] The AST node.
@@ -1267,6 +1277,25 @@ unsigned int cypher_ast_query_nclauses(const cypher_astnode_t *node);
 __cypherlang_pure
 const cypher_astnode_t *cypher_ast_query_get_clause(
         const cypher_astnode_t *node, unsigned int index);
+
+
+
+/**
+ * Set the clause of a `CYPHER_AST_QUERY` node.
+ *
+ * If the node is not an instance of `CYPHER_AST_QUERY` then the result will
+ * be undefined.
+ *
+ * If the clause is not an instance of `CYPHER_AST_QUERY_CLAUSE` then the result
+ * will be undefined.
+ *
+ * @param [node] The AST node.
+ * @param [clause] The AST clause node.
+ * @param [index] The index of the clause.
+ */
+void cypher_ast_query_set_clause(
+        cypher_astnode_t *astnode, cypher_astnode_t *clause,
+        unsigned int index);
 
 
 /**


### PR DESCRIPTION
Adds the new functions `cypher_astnode_set_child` and `cypher_ast_query_set_clause`, as well as fixing several bugs in the AST clone logic.