### PR TITLE
Allow WHERE predicates in node and edge patterns

### DIFF
--- a/lib/src/cypher-parser.h.in
+++ b/lib/src/cypher-parser.h.in
@@ -1984,9 +1984,9 @@ const cypher_astnode_t *cypher_ast_match_get_hint(
         const cypher_astnode_t *node, unsigned int index);
 
 /**
- * Get the predicate of a `CYPHER_AST_PREDICATE` node.
+ * Get the predicate of a `CYPHER_AST_MATCH` node.
  *
- * If the node is not an instance of `CYPHER_AST_PREDICATE` then the result
+ * If the node is not an instance of `CYPHER_AST_MATCH` then the result
  * will be undefined.
  *
  * @param [node] The AST node.
@@ -5141,6 +5141,7 @@ const cypher_astnode_t *cypher_ast_pattern_path_get_element(
  * @param [nlabels] The number of labels in the pattern.
  * @param [properties] A `CYPHER_AST_MAP` node, a `CYPHER_AST_PARAMETER` node,
  *         or null.
+ * @param [predicate] A `CYPHER_AST_EXPRESSION` node, or null.
  * @param [children] The children of the node.
  * @param [nchildren] The number of children.
  * @param [range] The input range.
@@ -5149,8 +5150,9 @@ const cypher_astnode_t *cypher_ast_pattern_path_get_element(
 __cypherlang_must_check
 cypher_astnode_t *cypher_ast_node_pattern(const cypher_astnode_t *identifier,
         cypher_astnode_t * const *labels, unsigned int nlabels,
-        const cypher_astnode_t *properties, cypher_astnode_t **children,
-        unsigned int nchildren, struct cypher_input_range range);
+        const cypher_astnode_t *properties, const cypher_astnode_t *predicate,
+        cypher_astnode_t **children, unsigned int nchildren,
+        struct cypher_input_range range);
 
 /**
  * Get the identifier of a `CYPHER_AST_NODE_PATTERN` node.
@@ -5206,6 +5208,20 @@ const cypher_astnode_t *cypher_ast_node_pattern_get_properties(
 
 
 /**
+ * Get the predicate of a `CYPHER_AST_NODE_PATTERN` node.
+ *
+ * If the node is not an instance of `CYPHER_AST_NODE_PATTERN` then the result
+ * will be undefined.
+ *
+ * @param [node] The AST node.
+ * @return A `CYPHER_AST_PREDICATE` node, or null.
+ */
+__cypherlang_pure
+const cypher_astnode_t *cypher_ast_node_pattern_get_predicate(
+        const cypher_astnode_t *node);
+
+
+/**
  * Construct a `CYPHER_AST_REL_PATTERN` node.
  *
  * @param [direction] The direction of the relationship.
@@ -5214,6 +5230,7 @@ const cypher_astnode_t *cypher_ast_node_pattern_get_properties(
  *         `CYPHER_AST_RELTYPE`.
  * @param [nreltypes] The number of relationship types in the pattern.
  * @param [properties] A `CYPHER_AST_MAP` node, a `CYPHER_AST_PARAMETER` node,
+ * @param [predicate] A `CYPHER_AST_EXPRESSION` node, or null.
  *         or null.
  * @param [varlength] A `CYPHER_AST_RANGE` node, or null.
  * @param [children] The children of the node.
@@ -5225,8 +5242,9 @@ __cypherlang_must_check
 cypher_astnode_t *cypher_ast_rel_pattern(enum cypher_rel_direction direction,
         const cypher_astnode_t *identifier, cypher_astnode_t * const *reltypes,
         unsigned int nreltypes, const cypher_astnode_t *properties,
-        const cypher_astnode_t *varlength, cypher_astnode_t **children,
-        unsigned int nchildren, struct cypher_input_range range);
+         const cypher_astnode_t *predicate, const cypher_astnode_t *varlength,
+         cypher_astnode_t **children, unsigned int nchildren,
+         struct cypher_input_range range);
 
 
 /**
@@ -5305,6 +5323,20 @@ const cypher_astnode_t *cypher_ast_rel_pattern_get_varlength(
  */
 __cypherlang_pure
 const cypher_astnode_t *cypher_ast_rel_pattern_get_properties(
+        const cypher_astnode_t *node);
+
+
+/**
+ * Get the predicate of a `CYPHER_AST_REL_PATTERN` node.
+ *
+ * If the node is not an instance of `CYPHER_AST_REL_PATTERN` then the result
+ * will be undefined.
+ *
+ * @param [node] The AST node.
+ * @return A `CYPHER_AST_PREDICATE` node, or null.
+ */
+__cypherlang_pure
+const cypher_astnode_t *cypher_ast_rel_pattern_get_predicate(
         const cypher_astnode_t *node);
 
 

--- a/lib/src/parser.c
+++ b/lib/src/parser.c
@@ -460,15 +460,17 @@ static cypher_astnode_t *_shortest_path(yycontext *yy, bool single,
         cypher_astnode_t *path);
 #define pattern_path() _pattern_path(yy)
 static cypher_astnode_t *_pattern_path(yycontext *yy);
-#define node_pattern(i, p) _node_pattern(yy, i, p)
+#define node_pattern(i, p, c) _node_pattern(yy, i, p, c)
 static cypher_astnode_t *_node_pattern(yycontext *yy,
-        cypher_astnode_t *identifier, cypher_astnode_t *properties);
+        cypher_astnode_t *identifier, cypher_astnode_t *properties,
+        cypher_astnode_t *predicate);
 #define simple_rel_pattern(d) \
-    _rel_pattern(yy, CYPHER_REL_##d, NULL, NULL, NULL)
-#define rel_pattern(d, i, r, p) _rel_pattern(yy, CYPHER_REL_##d, i, r, p)
+    _rel_pattern(yy, CYPHER_REL_##d, NULL, NULL, NULL, NULL)
+#define rel_pattern(d, i, r, p, c) _rel_pattern(yy, CYPHER_REL_##d, i, r, p, c)
 static cypher_astnode_t *_rel_pattern(yycontext *yy,
         enum cypher_rel_direction direction, cypher_astnode_t *identifier,
-        cypher_astnode_t *varlength, cypher_astnode_t *properties);
+        cypher_astnode_t *varlength, cypher_astnode_t *properties,
+        cypher_astnode_t *predicate);
 #define range(s, e) _range(yy, s, e)
 static cypher_astnode_t *_range(yycontext *yy, cypher_astnode_t *start,
         cypher_astnode_t *end);
@@ -2958,13 +2960,13 @@ cypher_astnode_t *_pattern_path(yycontext *yy)
 
 
 cypher_astnode_t *_node_pattern(yycontext *yy, cypher_astnode_t *identifier,
-        cypher_astnode_t *properties)
+        cypher_astnode_t *properties, cypher_astnode_t *predicate)
 {
     assert(yy->prev_block != NULL &&
             "An AST node can only be created immediately after a `>` in the grammar");
     cypher_astnode_t *node = cypher_ast_node_pattern(identifier,
             astnodes_elements(&(yy->prev_block->sequence)),
-            astnodes_size(&(yy->prev_block->sequence)), properties,
+            astnodes_size(&(yy->prev_block->sequence)), properties, predicate,
             astnodes_elements(&(yy->prev_block->children)),
             astnodes_size(&(yy->prev_block->children)),
             yy->prev_block->range);
@@ -2982,13 +2984,15 @@ cypher_astnode_t *_node_pattern(yycontext *yy, cypher_astnode_t *identifier,
 
 cypher_astnode_t *_rel_pattern(yycontext *yy,
         enum cypher_rel_direction direction, cypher_astnode_t *identifier,
-        cypher_astnode_t *varlength, cypher_astnode_t *properties)
+        cypher_astnode_t *varlength, cypher_astnode_t *properties,
+        cypher_astnode_t *predicate)
 {
     assert(yy->prev_block != NULL &&
             "An AST node can only be created immediately after a `>` in the grammar");
     cypher_astnode_t *node = cypher_ast_rel_pattern(direction, identifier,
             astnodes_elements(&(yy->prev_block->sequence)),
-            astnodes_size(&(yy->prev_block->sequence)), properties, varlength,
+            astnodes_size(&(yy->prev_block->sequence)),
+            properties, predicate, varlength,
             astnodes_elements(&(yy->prev_block->children)),
             astnodes_size(&(yy->prev_block->children)),
             yy->prev_block->range);

--- a/lib/src/parser.leg
+++ b/lib/src/parser.leg
@@ -802,7 +802,8 @@ node-pattern = < LEFT-PAREN -
     (i:identifier | i:_null_)
     ( n:label                          { sequence_add(n); }
     )* (p:pattern-properties | p:_null_)
-    RIGHT-PAREN >                      { $$ = node_pattern(i, p); }
+    ( WHERE c:expression | c:_null_ )
+    RIGHT-PAREN >                      { $$ = node_pattern(i, p, c); }
 
 relationship-pattern =
       < ( LEFT-ARROW-HEAD - DASH -
@@ -812,9 +813,11 @@ relationship-pattern =
             )
           | LEFT-SQ-PAREN - (i:identifier | i:_null_)
             rel-types? (l:rel-varlength | l:_null_)
-            (p:pattern-properties | p:_null_) RIGHT-SQ-PAREN - DASH 
-            ( - RIGHT-ARROW-HEAD >     { $$ = rel_pattern(BIDIRECTIONAL, i, l, p); }
-            | _empty_ >                { $$ = rel_pattern(INBOUND, i, l, p); }
+            (p:pattern-properties | p:_null_)
+            ( WHERE c:expression | c:_null_ )
+			RIGHT-SQ-PAREN - DASH
+            ( - RIGHT-ARROW-HEAD >     { $$ = rel_pattern(BIDIRECTIONAL, i, l, p, c); }
+            | _empty_ >                { $$ = rel_pattern(INBOUND, i, l, p, c); }
             )
           )
         | DASH -
@@ -824,9 +827,11 @@ relationship-pattern =
             )
           | LEFT-SQ-PAREN - (i:identifier | i:_null_)
             rel-types? (l:rel-varlength | l:_null_)
-            (p:pattern-properties | p:_null_) RIGHT-SQ-PAREN - DASH 
-            ( - RIGHT-ARROW-HEAD >     { $$ = rel_pattern(OUTBOUND, i, l, p); }
-            | _empty_ >                { $$ = rel_pattern(BIDIRECTIONAL, i, l, p); }
+            (p:pattern-properties | p:_null_)
+            ( WHERE c:expression | c:_null_ )
+			RIGHT-SQ-PAREN - DASH
+            ( - RIGHT-ARROW-HEAD >     { $$ = rel_pattern(OUTBOUND, i, l, p, c); }
+            | _empty_ >                { $$ = rel_pattern(BIDIRECTIONAL, i, l, p, c); }
             )
           )
         )

--- a/lib/test/check_errors.c
+++ b/lib/test/check_errors.c
@@ -295,7 +295,7 @@ START_TEST (track_error_position_across_statements)
     ck_assert_int_eq(pos.column, 11);
     ck_assert_int_eq(pos.offset, 71);
     ck_assert_str_eq(cypher_parse_error_message(err),
-            "Invalid input 'e': expected a label, '{', a parameter or ')'");
+            "Invalid input 'e': expected a label, '{', a parameter, WHERE or ')'");
 }
 END_TEST
 


### PR DESCRIPTION
Expand node and edge pattern structs, constructors, and getters to support inlined WHERE predicates.