### PR TITLE
Fix inequality when cloning predicate in all operations

### DIFF
--- a/lib/src/ast_none.c
+++ b/lib/src/ast_none.c
@@ -99,7 +99,7 @@ cypher_astnode_t *clone(const cypher_astnode_t *self,
 
     cypher_astnode_t *identifier = children[child_index(self, node->identifier)];
     cypher_astnode_t *expression = children[child_index(self, node->expression)];
-    cypher_astnode_t *predicate = (node->predicate != NULL) ? NULL :
+    cypher_astnode_t *predicate = (node->predicate == NULL) ? NULL :
             children[child_index(self, node->predicate)];
 
     return cypher_ast_none(identifier, expression, predicate, children,

--- a/lib/src/ast_pattern_comprehension.c
+++ b/lib/src/ast_pattern_comprehension.c
@@ -92,7 +92,7 @@ cypher_astnode_t *clone(const cypher_astnode_t *self,
     cypher_astnode_t *identifier = (node->identifier == NULL) ? NULL :
             children[child_index(self, node->identifier)];
     cypher_astnode_t *pattern = children[child_index(self, node->pattern)];
-    cypher_astnode_t *predicate = (node->predicate != NULL) ? NULL :
+    cypher_astnode_t *predicate = (node->predicate == NULL) ? NULL :
             children[child_index(self, node->predicate)];
     cypher_astnode_t *eval = children[child_index(self, node->eval)];
 

--- a/lib/src/ast_start.c
+++ b/lib/src/ast_start.c
@@ -98,7 +98,7 @@ cypher_astnode_t *clone(const cypher_astnode_t *self,
     {
         points[i] = children[child_index(self, node->points[i])];
     }
-    cypher_astnode_t *predicate = (node->predicate != NULL) ? NULL :
+    cypher_astnode_t *predicate = (node->predicate == NULL) ? NULL :
             children[child_index(self, node->predicate)];
 
     cypher_astnode_t *clone = cypher_ast_start(points, node->npoints,


### PR DESCRIPTION
This PR fixes https://github.com/RedisGraph/RedisGraph/issues/2271 and corrects the same problem in `ast_start.c`.