### PR TITLE
Fix map cloning logic

### DIFF
--- a/lib/src/ast_case.c
+++ b/lib/src/ast_case.c
@@ -96,13 +96,13 @@ cypher_astnode_t *clone(const cypher_astnode_t *self,
 
     cypher_astnode_t *expression = (node->expression == NULL) ? NULL :
             children[child_index(self, node->expression)];
-    cypher_astnode_t **alternatives = calloc(node->nalternatives,
+    cypher_astnode_t **alternatives = calloc(node->nalternatives * 2,
             sizeof(cypher_astnode_t *));
     if (alternatives == NULL)
     {
         return NULL;
     }
-    for (unsigned int i = 0; i < node->nalternatives; ++i)
+    for (unsigned int i = 0; i < node->nalternatives * 2; ++i)
     {
         alternatives[i] = children[child_index(self, node->alternatives[i])];
     }

--- a/lib/src/ast_map.c
+++ b/lib/src/ast_map.c
@@ -121,21 +121,18 @@ cypher_astnode_t *clone(const cypher_astnode_t *self,
     REQUIRE_TYPE(self, CYPHER_AST_MAP, NULL);
     struct map *node = container_of(self, struct map, _astnode);
 
-    cypher_astnode_t **pairs = calloc(node->nentries,
-            sizeof(cypher_astnode_t *));
-    if (pairs == NULL)
+	cypher_astnode_t *keys[node->nentries / 2];
+	cypher_astnode_t *values[node->nentries / 2];
+
+    for (unsigned int i = 0; i < node->nentries; i += 2)
     {
-        return NULL;
-    }
-    for (unsigned int i = 0; i < node->nentries; ++i)
-    {
-        pairs[i] = children[child_index(self, node->pairs[i])];
+        keys[i] = children[child_index(self, node->pairs[i])];
+        values[i] = children[child_index(self, node->pairs[i + 1])];
     }
 
-    cypher_astnode_t *clone = cypher_ast_pair_map(pairs, node->nentries,
+    cypher_astnode_t *clone = cypher_ast_map(keys, values, node->nentries,
             children, self->nchildren, self->range);
     int errsv = errno;
-    free(pairs);
     errno = errsv;
     return clone;
 }

--- a/lib/src/ast_map.c
+++ b/lib/src/ast_map.c
@@ -121,8 +121,19 @@ cypher_astnode_t *clone(const cypher_astnode_t *self,
     REQUIRE_TYPE(self, CYPHER_AST_MAP, NULL);
     struct map *node = container_of(self, struct map, _astnode);
 
-    cypher_astnode_t *keys[node->nentries / 2];
-    cypher_astnode_t *values[node->nentries / 2];
+    cypher_astnode_t **keys = calloc(node->nentries / 2,
+            sizeof(cypher_astnode_t *));
+    if (keys == NULL)
+    {
+        return NULL;
+    }
+
+    cypher_astnode_t **values = calloc(node->nentries / 2,
+            sizeof(cypher_astnode_t *));
+    if (values == NULL)
+    {
+        return NULL;
+    }
 
     for (unsigned int i = 0; i < node->nentries; i += 2)
     {
@@ -133,6 +144,8 @@ cypher_astnode_t *clone(const cypher_astnode_t *self,
     cypher_astnode_t *clone = cypher_ast_map(keys, values, node->nentries,
             children, self->nchildren, self->range);
     int errsv = errno;
+    free(keys);
+    free(values);
     errno = errsv;
     return clone;
 }

--- a/lib/src/ast_map.c
+++ b/lib/src/ast_map.c
@@ -121,8 +121,8 @@ cypher_astnode_t *clone(const cypher_astnode_t *self,
     REQUIRE_TYPE(self, CYPHER_AST_MAP, NULL);
     struct map *node = container_of(self, struct map, _astnode);
 
-	cypher_astnode_t *keys[node->nentries / 2];
-	cypher_astnode_t *values[node->nentries / 2];
+    cypher_astnode_t *keys[node->nentries / 2];
+    cypher_astnode_t *values[node->nentries / 2];
 
     for (unsigned int i = 0; i < node->nentries; i += 2)
     {


### PR DESCRIPTION
The clone routine for map AST nodes had erroneously called the constructor `cypher_ast_pair_map`.