### PR TITLE
Fix property name validation used by "create index for"

### DIFF
--- a/lib/src/parser.leg
+++ b/lib/src/parser.leg
@@ -544,10 +544,10 @@ atom =
     | function-application
     | identifier
 
-property-expression = _block_start_ p:atom
+property-expression = _block_start_ p:identifier
     ( DOT - n:prop-name _block_replace_
                                        { p = property_operator(p, n); }
-    )+ _block_merge_                   { $$ = p; }
+    ) _block_merge_                   { $$ = p; }
 
 # operator rules set yy->op during evaluation, for use in PREC_CHK() and
 # in PREC_PUSH(), and also push the operator to a stack after matching,

--- a/lib/src/parser.leg
+++ b/lib/src/parser.leg
@@ -132,9 +132,9 @@ create-index-on =
 create-index-for =
     < CREATE-INDEX-FOR
       ( LEFT-PAREN - i:identifier l:label RIGHT-PAREN -
-        ON - LEFT-PAREN p:property-expression
+        ON - LEFT-PAREN p:property-key-name
                                        { sequence_add(p); }
-        ( COMMA - p:property-expression
+        ( COMMA - p:property-key-name
                                        { sequence_add(p); }
         )* RIGHT-PAREN >
                                        { $$ = create_pattern_index(i, l, false);
@@ -142,9 +142,9 @@ create-index-for =
       | LEFT-PAREN - RIGHT-PAREN - (LEFT-ARROW-HEAD -)? DASH -
         LEFT-SQ-PAREN - i:identifier l:label RIGHT-SQ-PAREN -
         DASH - (RIGHT-ARROW-HEAD -)? LEFT-PAREN - RIGHT-PAREN -
-        ON - LEFT-PAREN p:property-expression
+        ON - LEFT-PAREN p:property-key-name
                                        { sequence_add(p); }
-        ( COMMA - p:property-expression
+        ( COMMA - p:property-key-name
                                        { sequence_add(p); }
         )* RIGHT-PAREN >
                                        { $$ = create_pattern_index(i, l, true);
@@ -544,10 +544,15 @@ atom =
     | function-application
     | identifier
 
-property-expression = _block_start_ p:identifier
+property-expression = _block_start_ p:atom
     ( DOT - n:prop-name _block_replace_
                                        { p = property_operator(p, n); }
-    ) _block_merge_                   { $$ = p; }
+    )+ _block_merge_                   { $$ = p; }
+
+property-key-name = _block_start_ p:identifier
+    ( DOT - n:prop-name _block_replace_
+                                       { p = property_operator(p, n); }
+    ) _block_merge_                    { $$ = p; }
 
 # operator rules set yy->op during evaluation, for use in PREC_CHK() and
 # in PREC_PUSH(), and also push the operator to a stack after matching,


### PR DESCRIPTION
Hi, this PR is part of the solution to Redisgraph issue: [Indexes can be created on invalid property names](https://github.com/RedisGraph/RedisGraph/issues/2484)

The fix was done creating a new property-key-name, and modifying the create-index-for to use property-key-name.

The change was based on the Grammar specification found in opencypher resources.
[openCypher Resources](https://opencypher.org/resources/)

I did not find how to run the library test, the tests will be done in Redisgraph.

This is the output using cypher-lint:

```
$ ./cypher-lint ../../../cypher/createindex.cyp.
../../../cypher/createindex.cyp:5:36: Invalid input '.': expected ',' or ')'
CREATE INDEX FOR (p:Person) ON (p.m.n, p.p.q);
                                   ^
../../../cypher/createindex.cyp:13:33: Invalid input '1': expected an identifier
CREATE INDEX FOR (p:Person) ON (1.b);
                                ^
../../../cypher/createindex.cyp:17:35: Invalid input '1': expected a property name
CREATE INDEX FOR (p:Person) ON (b.1);
                                  ^
../../../cypher/createindex.cyp:21:25: Invalid input ')': expected a label
CREATE INDEX FOR (Person) ON (surname);
                        ^
../../../cypher/createindex.cyp:25:40: Invalid input ')': expected '.'
CREATE INDEX FOR (p:Person) ON (surname);
                                       ^
../../../cypher/createindex.cyp:29:33: Invalid input ')': expected an identifier
CREATE INDEX FOR (p:Person) ON ()
                                ^
../../../cypher/createindex.cyp:31:37: Invalid input '.': expected ',' or ')'
CREATE INDEX FOR ()-[n:T]-() ON (n.p.q)
                                    ^
../../../cypher/createindex.cyp:34:34: Invalid input '1': expected an identifier
CREATE INDEX FOR ()-[n:T]-() ON (1.b)
                                 ^
```